### PR TITLE
Update CMake files and add clang-tidy checks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,38 +1,17 @@
 ---
 # Compliant to clang-foramt 11
 Language: Cpp
-Standard: Latest
+BasedOnStyle: LLVM
 AccessModifierOffset: -4
-AlignConsecutiveBitFields: true
-AlignConsecutiveMacros: true
-AlignEscapedNewlines: Right
-AlignOperands: true
-AllowAllArgumentsOnNextLine: true
-AllowAllConstructorInitializersOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
+AlignConsecutiveBitFields: AcrossComments
+AlignConsecutiveMacros: AcrossComments
 AllowShortBlocksOnASingleLine: Empty
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: Never
-AllowShortLambdasOnASingleLine: None
-AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
+AllowShortLambdasOnASingleLine: Inline
 AlwaysBreakTemplateDeclarations: Yes
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
-BreakConstructorInitializers: BeforeColon
-#BreakInheritanceList: AfterComma
-BreakStringLiterals: true
 ColumnLimit: 0
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-#EmptyLineAfterAccessModifier: Leave
-#EmptyLineBeforeAccessModifier: Leave
-IncludeBlocks: Preserve
+ContinuationIndentWidth: 8
 IncludeCategories:
   - Regex: '^<.*'
     Priority: 1
@@ -41,22 +20,8 @@ IncludeCategories:
   - Regex: '.*'
     Priority: 3
 IncludeIsMainRegex: '([-_](test|unittest))?$'
-IndentCaseBlocks: false
-IndentCaseLabels: false
-IndentExternBlock: AfterExternBlock
 IndentWidth: 4
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
 PointerAlignment: Left
-SortIncludes: true
-SortUsingDeclarations: true
 SpaceAfterTemplateKeyword: false
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeCtorInitializerColon: true
-SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatementsExceptForEachMacros
-SpacesBeforeTrailingComments: 1
-TabWidth: 4
-UseCRLF: false
-UseTab: Never
+SpaceBeforeParens: ControlStatementsExceptControlMacros
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,55 @@
+---
+Checks: >
+  -*,
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  bugprone-*,
+  cppcoreguidelines-*,
+  google-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -bugprone-easily-swappable-parameters,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-vararg,
+  -misc-no-recursion,
+  -modernize-avoid-c-arrays,
+  -modernize-return-braced-init-list,
+  -modernize-use-nodiscard,
+  -modernize-use-trailing-return-type,
+  -performance-no-int-to-ptr,
+  -readability-function-cognitive-complexity,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -readability-named-parameter,
+  -readability-qualified-auto,
+  -readability-redundant-access-specifiers
+
+WarningsAsErrors: '*'
+HeaderFilterRegex: '(uuidxx|tests)\/.*\.h$'
+
+CheckOptions:
+  - key: cppcoreguidelines-macro-usage.CheckCapsOnly
+    value: 1
+  - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: 1
+  - key: modernize-avoid-bind.PermissiveParameterList
+    value: 1
+  - key: readability-implicit-bool-conversion.AllowIntegerConditions
+    value: 1
+  - key: readability-implicit-bool-conversion.AllowPointerConditions
+    value: 1
+  - key: readability-magic-numbers.IgnorePowersOf2IntegerValues
+    value: 1
+  - key: readability-magic-numbers.IgnoredIntegerValues
+    value: 0;1;2;3;4;5;6;7;8;9;10;42;100;1000
+...

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+echo -e "Running clang-format-diff...\n"
+
+fmt_diff=$(git diff --no-ext -U0 --no-color --relative --cached | clang-format-diff.py -p1)
+
+colorize_diff='
+    /^+/ { printf "\033[1;32m" }
+    /^-/ { printf "\033[1;31m" }
+    // { print $0 "\033[0m"; }'
+
+if [ -n "$fmt_diff" ]; then
+    echo "$fmt_diff" | awk "$colorize_diff"
+    echo -e "\nPlease re-format above files before commit"
+    exit 1
+fi
+
+echo "clang-format-diff passed"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 
 # Detect if being bundled via sub-directory.
 if(NOT DEFINED PROJECT_NAME)
@@ -17,6 +17,7 @@ if(UUIDXX_NOT_SUBPROJECT)
   set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS OFF)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
   set(ROOT_DIR ${CMAKE_SOURCE_DIR})
 endif()

--- a/build.py
+++ b/build.py
@@ -13,9 +13,24 @@ import platform
 import shutil
 import subprocess
 
-from distutils.util import strtobool
-
 OS_WIN = 'Windows'
+
+
+# `distuils` is deprecated and will be removed since 3.12. Let's retain the
+# function.
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
 
 
 def default_generator():
@@ -124,9 +139,6 @@ class multiconf_subsystem():
 
         if self._gen:
             cmd.append(f'-G "{self._gen}"')
-
-        if self._clang_tidy:
-            cmd.append('-DUUIDXX_ENABLE_CLANG_TIDY=ON')
 
         clang_tidy = 'ON' if self._clang_tidy else 'OFF'
         cmd.append(f'-DUUIDXX_ENABLE_CLANG_TIDY={clang_tidy}')

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -5,7 +5,7 @@
 # MIT License
 # -----------
 #[[
-  Copyright (c) 2021 Lars Melchior and additional contributors
+  Copyright (c) 2019-2022 Lars Melchior and contributors
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
@@ -28,10 +28,25 @@
 
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
-set(CURRENT_CPM_VERSION 0.31.1)
+# Initialize logging prefix
+if(NOT CPM_INDENT)
+  set(CPM_INDENT
+      "CPM:"
+      CACHE INTERNAL ""
+  )
+endif()
 
+if(NOT COMMAND cpm_message)
+  function(cpm_message)
+    message(${ARGV})
+  endfunction()
+endif()
+
+set(CURRENT_CPM_VERSION 0.37.0)
+
+get_filename_component(CPM_CURRENT_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" REALPATH)
 if(CPM_DIRECTORY)
-  if(NOT CPM_DIRECTORY STREQUAL CMAKE_CURRENT_LIST_DIR)
+  if(NOT CPM_DIRECTORY STREQUAL CPM_CURRENT_DIRECTORY)
     if(CPM_VERSION VERSION_LESS CURRENT_CPM_VERSION)
       message(
         AUTHOR_WARNING
@@ -57,7 +72,35 @@ See https://github.com/cpm-cmake/CPM.cmake for more information."
   endif()
 endif()
 
+if(CURRENT_CPM_VERSION MATCHES "development-version")
+  message(
+    WARNING "${CPM_INDENT} Your project is using an unstable development version of CPM.cmake. \
+Please update to a recent release if possible. \
+See https://github.com/cpm-cmake/CPM.cmake for details."
+  )
+endif()
+
 set_property(GLOBAL PROPERTY CPM_INITIALIZED true)
+
+macro(cpm_set_policies)
+  # the policy allows us to change options without caching
+  cmake_policy(SET CMP0077 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
+  # the policy allows us to change set(CACHE) without caching
+  if(POLICY CMP0126)
+    cmake_policy(SET CMP0126 NEW)
+    set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
+  endif()
+
+  # The policy uses the download time for timestamp, instead of the timestamp in the archive. This
+  # allows for proper rebuilds when a projects url changes
+  if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+    set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+  endif()
+endmacro()
+cpm_set_policies()
 
 option(CPM_USE_LOCAL_PACKAGES "Always try to use `find_package` to get dependencies"
        $ENV{CPM_USE_LOCAL_PACKAGES}
@@ -76,13 +119,17 @@ option(CPM_INCLUDE_ALL_IN_PACKAGE_LOCK
        "Add all packages added through CPM.cmake to the package lock"
        $ENV{CPM_INCLUDE_ALL_IN_PACKAGE_LOCK}
 )
+option(CPM_USE_NAMED_CACHE_DIRECTORIES
+       "Use additional directory of package name in cache on the most nested level."
+       $ENV{CPM_USE_NAMED_CACHE_DIRECTORIES}
+)
 
 set(CPM_VERSION
     ${CURRENT_CPM_VERSION}
     CACHE INTERNAL ""
 )
 set(CPM_DIRECTORY
-    ${CMAKE_CURRENT_LIST_DIR}
+    ${CPM_CURRENT_DIRECTORY}
     CACHE INTERNAL ""
 )
 set(CPM_FILE
@@ -132,7 +179,6 @@ if(NOT CPM_DONT_CREATE_PACKAGE_LOCK)
 endif()
 
 include(FetchContent)
-include(CMakeParseArguments)
 
 # Try to infer package name from git repository uri (path or url)
 function(cpm_package_name_from_git_uri URI RESULT)
@@ -192,19 +238,14 @@ function(cpm_package_name_and_ver_from_url url outName outVer)
   endif()
 endfunction()
 
-# Initialize logging prefix
-if(NOT CPM_INDENT)
-  set(CPM_INDENT
-      "CPM:"
-      CACHE INTERNAL ""
-  )
-endif()
-
 function(cpm_find_package NAME VERSION)
   string(REPLACE " " ";" EXTRA_ARGS "${ARGN}")
   find_package(${NAME} ${VERSION} ${EXTRA_ARGS} QUIET)
   if(${CPM_ARGS_NAME}_FOUND)
-    message(STATUS "${CPM_INDENT} using local package ${CPM_ARGS_NAME}@${VERSION}")
+    if(DEFINED ${CPM_ARGS_NAME}_VERSION)
+      set(VERSION ${${CPM_ARGS_NAME}_VERSION})
+    endif()
+    cpm_message(STATUS "${CPM_INDENT} Using local package ${CPM_ARGS_NAME}@${VERSION}")
     CPMRegisterPackage(${CPM_ARGS_NAME} "${VERSION}")
     set(CPM_PACKAGE_FOUND
         YES
@@ -224,7 +265,7 @@ function(cpm_create_module_file Name)
   if(NOT CPM_DONT_UPDATE_MODULE_PATH)
     # erase any previous modules
     file(WRITE ${CPM_MODULE_PATH}/Find${Name}.cmake
-         "include(${CPM_FILE})\n${ARGN}\nset(${Name}_FOUND TRUE)"
+         "include(\"${CPM_FILE}\")\n${ARGN}\nset(${Name}_FOUND TRUE)"
     )
   endif()
 endfunction()
@@ -241,13 +282,19 @@ function(CPMFindPackage)
     endif()
   endif()
 
-  if(CPM_DOWNLOAD_ALL)
+  set(downloadPackage ${CPM_DOWNLOAD_ALL})
+  if(DEFINED CPM_DOWNLOAD_${CPM_ARGS_NAME})
+    set(downloadPackage ${CPM_DOWNLOAD_${CPM_ARGS_NAME}})
+  elseif(DEFINED ENV{CPM_DOWNLOAD_${CPM_ARGS_NAME}})
+    set(downloadPackage $ENV{CPM_DOWNLOAD_${CPM_ARGS_NAME}})
+  endif()
+  if(downloadPackage)
     CPMAddPackage(${ARGN})
     cpm_export_variables(${CPM_ARGS_NAME})
     return()
   endif()
 
-  cpm_check_if_package_already_added(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" "${CPM_ARGS_OPTIONS}")
+  cpm_check_if_package_already_added(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}")
   if(CPM_PACKAGE_ALREADY_ADDED)
     cpm_export_variables(${CPM_ARGS_NAME})
     return()
@@ -263,25 +310,14 @@ function(CPMFindPackage)
 endfunction()
 
 # checks if a package has been added before
-function(cpm_check_if_package_already_added CPM_ARGS_NAME CPM_ARGS_VERSION CPM_ARGS_OPTIONS)
+function(cpm_check_if_package_already_added CPM_ARGS_NAME CPM_ARGS_VERSION)
   if("${CPM_ARGS_NAME}" IN_LIST CPM_PACKAGES)
     CPMGetPackageVersion(${CPM_ARGS_NAME} CPM_PACKAGE_VERSION)
     if("${CPM_PACKAGE_VERSION}" VERSION_LESS "${CPM_ARGS_VERSION}")
       message(
         WARNING
-          "${CPM_INDENT} requires a newer version of ${CPM_ARGS_NAME} (${CPM_ARGS_VERSION}) than currently included (${CPM_PACKAGE_VERSION})."
+          "${CPM_INDENT} Requires a newer version of ${CPM_ARGS_NAME} (${CPM_ARGS_VERSION}) than currently included (${CPM_PACKAGE_VERSION})."
       )
-    endif()
-    if(CPM_ARGS_OPTIONS)
-      foreach(OPTION ${CPM_ARGS_OPTIONS})
-        cpm_parse_option(${OPTION})
-        if(NOT "${${OPTION_KEY}}" STREQUAL "${OPTION_VALUE}")
-          message(
-            WARNING
-              "${CPM_INDENT} ignoring package option for ${CPM_ARGS_NAME}: ${OPTION_KEY} = ${OPTION_VALUE} (${${OPTION_KEY}})"
-          )
-        endif()
-      endforeach()
     endif()
     cpm_get_fetch_properties(${CPM_ARGS_NAME})
     set(${CPM_ARGS_NAME}_ADDED NO)
@@ -314,6 +350,9 @@ function(cpm_parse_add_package_single_arg arg outArgs)
     elseif(scheme STREQUAL "gl")
       set(out "GITLAB_REPOSITORY;${uri}")
       set(packageType "git")
+    elseif(scheme STREQUAL "bb")
+      set(out "BITBUCKET_REPOSITORY;${uri}")
+      set(packageType "git")
       # A CPM-specific scheme was not found. Looks like this is a generic URL so try to determine
       # type
     elseif(arg MATCHES ".git/?(@|#|$)")
@@ -334,11 +373,11 @@ function(cpm_parse_add_package_single_arg arg outArgs)
       set(packageType "git")
     else()
       # Give up
-      message(FATAL_ERROR "CPM: Can't determine package type of '${arg}'")
+      message(FATAL_ERROR "${CPM_INDENT} Can't determine package type of '${arg}'")
     endif()
   endif()
 
-  # For all packages we interpret @... as version. Only replace the last occurence. Thus URIs
+  # For all packages we interpret @... as version. Only replace the last occurrence. Thus URIs
   # containing '@' can be used
   string(REGEX REPLACE "@([^@]+)$" ";VERSION;\\1" out "${out}")
 
@@ -354,7 +393,7 @@ function(cpm_parse_add_package_single_arg arg outArgs)
   else()
     # We should never get here. This is an assertion and hitting it means there's a bug in the code
     # above. A packageType was set, but not handled by this if-else.
-    message(FATAL_ERROR "CPM: Unsupported package type '${packageType}' of '${arg}'")
+    message(FATAL_ERROR "${CPM_INDENT} Unsupported package type '${packageType}' of '${arg}'")
   endif()
 
   set(${outArgs}
@@ -363,8 +402,113 @@ function(cpm_parse_add_package_single_arg arg outArgs)
   )
 endfunction()
 
+# Check that the working directory for a git repo is clean
+function(cpm_check_git_working_dir_is_clean repoPath gitTag isClean)
+
+  find_package(Git REQUIRED)
+
+  if(NOT GIT_EXECUTABLE)
+    # No git executable, assume directory is clean
+    set(${isClean}
+        TRUE
+        PARENT_SCOPE
+    )
+    return()
+  endif()
+
+  # check for uncommitted changes
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} status --porcelain
+    RESULT_VARIABLE resultGitStatus
+    OUTPUT_VARIABLE repoStatus
+    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
+    WORKING_DIRECTORY ${repoPath}
+  )
+  if(resultGitStatus)
+    # not supposed to happen, assume clean anyway
+    message(WARNING "${CPM_INDENT} Calling git status on folder ${repoPath} failed")
+    set(${isClean}
+        TRUE
+        PARENT_SCOPE
+    )
+    return()
+  endif()
+
+  if(NOT "${repoStatus}" STREQUAL "")
+    set(${isClean}
+        FALSE
+        PARENT_SCOPE
+    )
+    return()
+  endif()
+
+  # check for committed changes
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} diff -s --exit-code ${gitTag}
+    RESULT_VARIABLE resultGitDiff
+    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_QUIET
+    WORKING_DIRECTORY ${repoPath}
+  )
+
+  if(${resultGitDiff} EQUAL 0)
+    set(${isClean}
+        TRUE
+        PARENT_SCOPE
+    )
+  else()
+    set(${isClean}
+        FALSE
+        PARENT_SCOPE
+    )
+  endif()
+
+endfunction()
+
+# method to overwrite internal FetchContent properties, to allow using CPM.cmake to overload
+# FetchContent calls. As these are internal cmake properties, this method should be used carefully
+# and may need modification in future CMake versions. Source:
+# https://github.com/Kitware/CMake/blob/dc3d0b5a0a7d26d43d6cfeb511e224533b5d188f/Modules/FetchContent.cmake#L1152
+function(cpm_override_fetchcontent contentName)
+  cmake_parse_arguments(PARSE_ARGV 1 arg "" "SOURCE_DIR;BINARY_DIR" "")
+  if(NOT "${arg_UNPARSED_ARGUMENTS}" STREQUAL "")
+    message(FATAL_ERROR "${CPM_INDENT} Unsupported arguments: ${arg_UNPARSED_ARGUMENTS}")
+  endif()
+
+  string(TOLOWER ${contentName} contentNameLower)
+  set(prefix "_FetchContent_${contentNameLower}")
+
+  set(propertyName "${prefix}_sourceDir")
+  define_property(
+    GLOBAL
+    PROPERTY ${propertyName}
+    BRIEF_DOCS "Internal implementation detail of FetchContent_Populate()"
+    FULL_DOCS "Details used by FetchContent_Populate() for ${contentName}"
+  )
+  set_property(GLOBAL PROPERTY ${propertyName} "${arg_SOURCE_DIR}")
+
+  set(propertyName "${prefix}_binaryDir")
+  define_property(
+    GLOBAL
+    PROPERTY ${propertyName}
+    BRIEF_DOCS "Internal implementation detail of FetchContent_Populate()"
+    FULL_DOCS "Details used by FetchContent_Populate() for ${contentName}"
+  )
+  set_property(GLOBAL PROPERTY ${propertyName} "${arg_BINARY_DIR}")
+
+  set(propertyName "${prefix}_populated")
+  define_property(
+    GLOBAL
+    PROPERTY ${propertyName}
+    BRIEF_DOCS "Internal implementation detail of FetchContent_Populate()"
+    FULL_DOCS "Details used by FetchContent_Populate() for ${contentName}"
+  )
+  set_property(GLOBAL PROPERTY ${propertyName} TRUE)
+endfunction()
+
 # Download and add a package from source
 function(CPMAddPackage)
+  cpm_set_policies()
+
   list(LENGTH ARGN argnLength)
   if(argnLength EQUAL 1)
     cpm_parse_add_package_single_arg("${ARGN}" ARGN)
@@ -381,6 +525,7 @@ function(CPMAddPackage)
       DOWNLOAD_ONLY
       GITHUB_REPOSITORY
       GITLAB_REPOSITORY
+      BITBUCKET_REPOSITORY
       GIT_REPOSITORY
       SOURCE_DIR
       DOWNLOAD_COMMAND
@@ -388,6 +533,7 @@ function(CPMAddPackage)
       NO_CACHE
       GIT_SHALLOW
       EXCLUDE_FROM_ALL
+      SOURCE_SUBDIR
   )
 
   set(multiValueArgs URL OPTIONS)
@@ -410,10 +556,10 @@ function(CPMAddPackage)
 
   if(DEFINED CPM_ARGS_GITHUB_REPOSITORY)
     set(CPM_ARGS_GIT_REPOSITORY "https://github.com/${CPM_ARGS_GITHUB_REPOSITORY}.git")
-  endif()
-
-  if(DEFINED CPM_ARGS_GITLAB_REPOSITORY)
+  elseif(DEFINED CPM_ARGS_GITLAB_REPOSITORY)
     set(CPM_ARGS_GIT_REPOSITORY "https://gitlab.com/${CPM_ARGS_GITLAB_REPOSITORY}.git")
+  elseif(DEFINED CPM_ARGS_BITBUCKET_REPOSITORY)
+    set(CPM_ARGS_GIT_REPOSITORY "https://bitbucket.org/${CPM_ARGS_BITBUCKET_REPOSITORY}.git")
   endif()
 
   if(DEFINED CPM_ARGS_GIT_REPOSITORY)
@@ -461,12 +607,12 @@ function(CPMAddPackage)
   if(NOT DEFINED CPM_ARGS_NAME)
     message(
       FATAL_ERROR
-        "CPM: 'NAME' was not provided and couldn't be automatically inferred for package added with arguments: '${ARGN}'"
+        "${CPM_INDENT} 'NAME' was not provided and couldn't be automatically inferred for package added with arguments: '${ARGN}'"
     )
   endif()
 
   # Check if package has been added before
-  cpm_check_if_package_already_added(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" "${CPM_ARGS_OPTIONS}")
+  cpm_check_if_package_already_added(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}")
   if(CPM_PACKAGE_ALREADY_ADDED)
     cpm_export_variables(${CPM_ARGS_NAME})
     return()
@@ -477,10 +623,13 @@ function(CPMAddPackage)
     set(PACKAGE_SOURCE ${CPM_${CPM_ARGS_NAME}_SOURCE})
     set(CPM_${CPM_ARGS_NAME}_SOURCE "")
     CPMAddPackage(
-      NAME ${CPM_ARGS_NAME}
-      SOURCE_DIR ${PACKAGE_SOURCE}
+      NAME "${CPM_ARGS_NAME}"
+      SOURCE_DIR "${PACKAGE_SOURCE}"
+      EXCLUDE_FROM_ALL "${CPM_ARGS_EXCLUDE_FROM_ALL}"
+      OPTIONS "${CPM_ARGS_OPTIONS}"
+      SOURCE_SUBDIR "${CPM_ARGS_SOURCE_SUBDIR}"
+      DOWNLOAD_ONLY "${DOWNLOAD_ONLY}"
       FORCE True
-      OPTIONS ${CPM_ARGS_OPTIONS}
     )
     cpm_export_variables(${CPM_ARGS_NAME})
     return()
@@ -493,7 +642,7 @@ function(CPMAddPackage)
     CPMAddPackage(${declaration})
     cpm_export_variables(${CPM_ARGS_NAME})
     # checking again to ensure version and option compatibility
-    cpm_check_if_package_already_added(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" "${CPM_ARGS_OPTIONS}")
+    cpm_check_if_package_already_added(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}")
     return()
   endif()
 
@@ -508,22 +657,12 @@ function(CPMAddPackage)
     if(CPM_LOCAL_PACKAGES_ONLY)
       message(
         SEND_ERROR
-          "CPM: ${CPM_ARGS_NAME} not found via find_package(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION})"
+          "${CPM_INDENT} ${CPM_ARGS_NAME} not found via find_package(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION})"
       )
     endif()
   endif()
 
   CPMRegisterPackage("${CPM_ARGS_NAME}" "${CPM_ARGS_VERSION}")
-
-  if(CPM_ARGS_OPTIONS)
-    foreach(OPTION ${CPM_ARGS_OPTIONS})
-      cpm_parse_option(${OPTION})
-      set(${OPTION_KEY}
-          ${OPTION_VALUE}
-          CACHE INTERNAL ""
-      )
-    endforeach()
-  endif()
 
   if(DEFINED CPM_ARGS_GIT_TAG)
     set(PACKAGE_INFO "${CPM_ARGS_GIT_TAG}")
@@ -533,29 +672,80 @@ function(CPMAddPackage)
     set(PACKAGE_INFO "${CPM_ARGS_VERSION}")
   endif()
 
+  if(DEFINED FETCHCONTENT_BASE_DIR)
+    # respect user's FETCHCONTENT_BASE_DIR if set
+    set(CPM_FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR})
+  else()
+    set(CPM_FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/_deps)
+  endif()
+
   if(DEFINED CPM_ARGS_DOWNLOAD_COMMAND)
     list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS DOWNLOAD_COMMAND ${CPM_ARGS_DOWNLOAD_COMMAND})
   elseif(DEFINED CPM_ARGS_SOURCE_DIR)
     list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS SOURCE_DIR ${CPM_ARGS_SOURCE_DIR})
+    if(NOT IS_ABSOLUTE ${CPM_ARGS_SOURCE_DIR})
+      # Expand `CPM_ARGS_SOURCE_DIR` relative path. This is important because EXISTS doesn't work
+      # for relative paths.
+      get_filename_component(
+        source_directory ${CPM_ARGS_SOURCE_DIR} REALPATH BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}
+      )
+    else()
+      set(source_directory ${CPM_ARGS_SOURCE_DIR})
+    endif()
+    if(NOT EXISTS ${source_directory})
+      string(TOLOWER ${CPM_ARGS_NAME} lower_case_name)
+      # remove timestamps so CMake will re-download the dependency
+      file(REMOVE_RECURSE "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-subbuild")
+    endif()
   elseif(CPM_SOURCE_CACHE AND NOT CPM_ARGS_NO_CACHE)
     string(TOLOWER ${CPM_ARGS_NAME} lower_case_name)
     set(origin_parameters ${CPM_ARGS_UNPARSED_ARGUMENTS})
     list(SORT origin_parameters)
-    string(SHA1 origin_hash "${origin_parameters}")
-    set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${origin_hash})
+    if(CPM_USE_NAMED_CACHE_DIRECTORIES)
+      string(SHA1 origin_hash "${origin_parameters};NEW_CACHE_STRUCTURE_TAG")
+      set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${origin_hash}/${CPM_ARGS_NAME})
+    else()
+      string(SHA1 origin_hash "${origin_parameters}")
+      set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${origin_hash})
+    endif()
+    # Expand `download_directory` relative path. This is important because EXISTS doesn't work for
+    # relative paths.
+    get_filename_component(download_directory ${download_directory} ABSOLUTE)
     list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS SOURCE_DIR ${download_directory})
+
+    file(LOCK ${download_directory}/../cmake.lock)
+
     if(EXISTS ${download_directory})
-      # avoid FetchContent modules to improve performance
-      set(${CPM_ARGS_NAME}_BINARY_DIR ${CMAKE_BINARY_DIR}/_deps/${lower_case_name}-build)
-      set(${CPM_ARGS_NAME}_ADDED YES)
-      set(${CPM_ARGS_NAME}_SOURCE_DIR ${download_directory})
-      if(NOT CPM_ARGS_DOWNLOAD_ONLY AND EXISTS ${download_directory}/CMakeLists.txt)
-        cpm_add_subdirectory(
-          ${download_directory} ${${CPM_ARGS_NAME}_BINARY_DIR} "${CPM_ARGS_EXCLUDE_FROM_ALL}"
-        )
+      cpm_store_fetch_properties(
+        ${CPM_ARGS_NAME} "${download_directory}"
+        "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-build"
+      )
+      cpm_get_fetch_properties("${CPM_ARGS_NAME}")
+
+      if(DEFINED CPM_ARGS_GIT_TAG AND NOT (PATCH_COMMAND IN_LIST CPM_ARGS_UNPARSED_ARGUMENTS))
+        # warn if cache has been changed since checkout
+        cpm_check_git_working_dir_is_clean(${download_directory} ${CPM_ARGS_GIT_TAG} IS_CLEAN)
+        if(NOT ${IS_CLEAN})
+          message(
+            WARNING "${CPM_INDENT} Cache for ${CPM_ARGS_NAME} (${download_directory}) is dirty"
+          )
+        endif()
       endif()
-      set(CPM_SKIP_FETCH TRUE)
+
+      cpm_add_subdirectory(
+        "${CPM_ARGS_NAME}" "${DOWNLOAD_ONLY}"
+        "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}" "${${CPM_ARGS_NAME}_BINARY_DIR}"
+        "${CPM_ARGS_EXCLUDE_FROM_ALL}" "${CPM_ARGS_OPTIONS}"
+      )
       set(PACKAGE_INFO "${PACKAGE_INFO} at ${download_directory}")
+
+      # As the source dir is already cached/populated, we override the call to FetchContent.
+      set(CPM_SKIP_FETCH TRUE)
+      cpm_override_fetchcontent(
+        "${lower_case_name}" SOURCE_DIR "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}"
+        BINARY_DIR "${${CPM_ARGS_NAME}_BINARY_DIR}"
+      )
+
     else()
       # Enable shallow clone when GIT_TAG is not a commit hash. Our guess may not be accurate, but
       # it should guarantee no commit hash get mis-detected.
@@ -567,12 +757,12 @@ function(CPMAddPackage)
       endif()
 
       # remove timestamps so CMake will re-download the dependency
-      file(REMOVE_RECURSE ${CMAKE_BINARY_DIR}/_deps/${lower_case_name}-subbuild)
+      file(REMOVE_RECURSE ${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-subbuild)
       set(PACKAGE_INFO "${PACKAGE_INFO} to ${download_directory}")
     endif()
   endif()
 
-  cpm_create_module_file(${CPM_ARGS_NAME} "CPMAddPackage(${ARGN})")
+  cpm_create_module_file(${CPM_ARGS_NAME} "CPMAddPackage(\"${ARGN}\")")
 
   if(CPM_PACKAGE_LOCK_ENABLED)
     if((CPM_ARGS_VERSION AND NOT CPM_ARGS_SOURCE_DIR) OR CPM_INCLUDE_ALL_IN_PACKAGE_LOCK)
@@ -584,16 +774,27 @@ function(CPMAddPackage)
     endif()
   endif()
 
-  message(
-    STATUS "${CPM_INDENT} adding package ${CPM_ARGS_NAME}@${CPM_ARGS_VERSION} (${PACKAGE_INFO})"
+  cpm_message(
+    STATUS "${CPM_INDENT} Adding package ${CPM_ARGS_NAME}@${CPM_ARGS_VERSION} (${PACKAGE_INFO})"
   )
 
   if(NOT CPM_SKIP_FETCH)
     cpm_declare_fetch(
       "${CPM_ARGS_NAME}" "${CPM_ARGS_VERSION}" "${PACKAGE_INFO}" "${CPM_ARGS_UNPARSED_ARGUMENTS}"
     )
-    cpm_fetch_package("${CPM_ARGS_NAME}" "${DOWNLOAD_ONLY}" "${CPM_ARGS_EXCLUDE_FROM_ALL}")
+    cpm_fetch_package("${CPM_ARGS_NAME}" populated)
+    if(${populated})
+      cpm_add_subdirectory(
+        "${CPM_ARGS_NAME}" "${DOWNLOAD_ONLY}"
+        "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}" "${${CPM_ARGS_NAME}_BINARY_DIR}"
+        "${CPM_ARGS_EXCLUDE_FROM_ALL}" "${CPM_ARGS_OPTIONS}"
+      )
+    endif()
     cpm_get_fetch_properties("${CPM_ARGS_NAME}")
+  endif()
+
+  if(EXISTS ${download_directory}/../cmake.lock)
+    file(LOCK ${download_directory}/../cmake.lock RELEASE)
   endif()
 
   set(${CPM_ARGS_NAME}_ADDED YES)
@@ -605,7 +806,7 @@ macro(CPMGetPackage Name)
   if(DEFINED "CPM_DECLARATION_${Name}")
     CPMAddPackage(NAME ${Name})
   else()
-    message(SEND_ERROR "Cannot retrieve package ${Name}: no declaration available")
+    message(SEND_ERROR "${CPM_INDENT} Cannot retrieve package ${Name}: no declaration available")
   endif()
 endmacro()
 
@@ -623,10 +824,14 @@ macro(cpm_export_variables name)
       "${${name}_ADDED}"
       PARENT_SCOPE
   )
+  set(CPM_LAST_PACKAGE_NAME
+      "${name}"
+      PARENT_SCOPE
+  )
 endmacro()
 
 # declares a package, so that any call to CPMAddPackage for the package name will use these
-# arguments instead. Previous declarations will not be overriden.
+# arguments instead. Previous declarations will not be overridden.
 macro(CPMDeclarePackage Name)
   if(NOT DEFINED "CPM_DECLARATION_${Name}")
     set("CPM_DECLARATION_${Name}" "${ARGN}")
@@ -649,7 +854,7 @@ function(cpm_add_comment_to_package_lock Name)
   endif()
 endfunction()
 
-# includes the package lock file if it exists and creates a target `cpm-write-package-lock` to
+# includes the package lock file if it exists and creates a target `cpm-update-package-lock` to
 # update it
 macro(CPMUsePackageLock file)
   if(NOT CPM_DONT_CREATE_PACKAGE_LOCK)
@@ -691,7 +896,7 @@ endfunction()
 # declares a package in FetchContent_Declare
 function(cpm_declare_fetch PACKAGE VERSION INFO)
   if(${CPM_DRY_RUN})
-    message(STATUS "${CPM_INDENT} package not declared (dry run)")
+    cpm_message(STATUS "${CPM_INDENT} Package not declared (dry run)")
     return()
   endif()
 
@@ -703,61 +908,110 @@ function(cpm_get_fetch_properties PACKAGE)
   if(${CPM_DRY_RUN})
     return()
   endif()
-  FetchContent_GetProperties(${PACKAGE})
-  string(TOLOWER ${PACKAGE} lpackage)
+
   set(${PACKAGE}_SOURCE_DIR
-      "${${lpackage}_SOURCE_DIR}"
+      "${CPM_PACKAGE_${PACKAGE}_SOURCE_DIR}"
       PARENT_SCOPE
   )
   set(${PACKAGE}_BINARY_DIR
-      "${${lpackage}_BINARY_DIR}"
+      "${CPM_PACKAGE_${PACKAGE}_BINARY_DIR}"
       PARENT_SCOPE
   )
 endfunction()
 
-function(cpm_add_subdirectory SOURCE_DIR BINARY_DIR EXCLUDE)
-  if(EXCLUDE)
-    set(addSubdirectoryExtraArgs EXCLUDE_FROM_ALL)
-  else()
-    set(addSubdirectoryExtraArgs "")
+function(cpm_store_fetch_properties PACKAGE source_dir binary_dir)
+  if(${CPM_DRY_RUN})
+    return()
   endif()
-  add_subdirectory(${SOURCE_DIR} ${BINARY_DIR} ${addSubdirectoryExtraArgs})
+
+  set(CPM_PACKAGE_${PACKAGE}_SOURCE_DIR
+      "${source_dir}"
+      CACHE INTERNAL ""
+  )
+  set(CPM_PACKAGE_${PACKAGE}_BINARY_DIR
+      "${binary_dir}"
+      CACHE INTERNAL ""
+  )
 endfunction()
 
-# downloads a previously declared package via FetchContent
-function(cpm_fetch_package PACKAGE DOWNLOAD_ONLY EXCLUDE)
+# adds a package as a subdirectory if viable, according to provided options
+function(
+  cpm_add_subdirectory
+  PACKAGE
+  DOWNLOAD_ONLY
+  SOURCE_DIR
+  BINARY_DIR
+  EXCLUDE
+  OPTIONS
+)
+  if(NOT DOWNLOAD_ONLY AND EXISTS ${SOURCE_DIR}/CMakeLists.txt)
+    if(EXCLUDE)
+      set(addSubdirectoryExtraArgs EXCLUDE_FROM_ALL)
+    else()
+      set(addSubdirectoryExtraArgs "")
+    endif()
+    if(OPTIONS)
+      foreach(OPTION ${OPTIONS})
+        cpm_parse_option("${OPTION}")
+        set(${OPTION_KEY} "${OPTION_VALUE}")
+      endforeach()
+    endif()
+    set(CPM_OLD_INDENT "${CPM_INDENT}")
+    set(CPM_INDENT "${CPM_INDENT} ${PACKAGE}:")
+    add_subdirectory(${SOURCE_DIR} ${BINARY_DIR} ${addSubdirectoryExtraArgs})
+    set(CPM_INDENT "${CPM_OLD_INDENT}")
+  endif()
+endfunction()
+
+# downloads a previously declared package via FetchContent and exports the variables
+# `${PACKAGE}_SOURCE_DIR` and `${PACKAGE}_BINARY_DIR` to the parent scope
+function(cpm_fetch_package PACKAGE populated)
+  set(${populated}
+      FALSE
+      PARENT_SCOPE
+  )
   if(${CPM_DRY_RUN})
-    message(STATUS "${CPM_INDENT} package ${PACKAGE} not fetched (dry run)")
+    cpm_message(STATUS "${CPM_INDENT} Package ${PACKAGE} not fetched (dry run)")
     return()
   endif()
 
   FetchContent_GetProperties(${PACKAGE})
+
   string(TOLOWER "${PACKAGE}" lower_case_name)
 
   if(NOT ${lower_case_name}_POPULATED)
     FetchContent_Populate(${PACKAGE})
-    if(NOT DOWNLOAD_ONLY AND EXISTS ${${lower_case_name}_SOURCE_DIR}/CMakeLists.txt)
-      set(CPM_OLD_INDENT "${CPM_INDENT}")
-      set(CPM_INDENT "${CPM_INDENT} ${PACKAGE}:")
-      cpm_add_subdirectory(
-        ${${lower_case_name}_SOURCE_DIR} ${${lower_case_name}_BINARY_DIR} "${EXCLUDE}"
-      )
-      set(CPM_INDENT "${CPM_OLD_INDENT}")
-    endif()
+    set(${populated}
+        TRUE
+        PARENT_SCOPE
+    )
   endif()
+
+  cpm_store_fetch_properties(
+    ${CPM_ARGS_NAME} ${${lower_case_name}_SOURCE_DIR} ${${lower_case_name}_BINARY_DIR}
+  )
+
+  set(${PACKAGE}_SOURCE_DIR
+      ${${lower_case_name}_SOURCE_DIR}
+      PARENT_SCOPE
+  )
+  set(${PACKAGE}_BINARY_DIR
+      ${${lower_case_name}_BINARY_DIR}
+      PARENT_SCOPE
+  )
 endfunction()
 
 # splits a package option
 function(cpm_parse_option OPTION)
-  string(REGEX MATCH "^[^ ]+" OPTION_KEY ${OPTION})
-  string(LENGTH ${OPTION} OPTION_LENGTH)
-  string(LENGTH ${OPTION_KEY} OPTION_KEY_LENGTH)
+  string(REGEX MATCH "^[^ ]+" OPTION_KEY "${OPTION}")
+  string(LENGTH "${OPTION}" OPTION_LENGTH)
+  string(LENGTH "${OPTION_KEY}" OPTION_KEY_LENGTH)
   if(OPTION_KEY_LENGTH STREQUAL OPTION_LENGTH)
     # no value for key provided, assume user wants to set option to "ON"
     set(OPTION_VALUE "ON")
   else()
     math(EXPR OPTION_KEY_LENGTH "${OPTION_KEY_LENGTH}+1")
-    string(SUBSTRING ${OPTION} "${OPTION_KEY_LENGTH}" "-1" OPTION_VALUE)
+    string(SUBSTRING "${OPTION}" "${OPTION_KEY_LENGTH}" "-1" OPTION_VALUE)
   endif()
   set(OPTION_KEY
       "${OPTION_KEY}"
@@ -787,7 +1041,7 @@ function(cpm_get_version_from_git_tag GIT_TAG RESULT)
   endif()
 endfunction()
 
-# guesses if the git tag is a commit hash or an actual tag or a branch nane.
+# guesses if the git tag is a commit hash or an actual tag or a branch name.
 function(cpm_is_git_tag_commit_hash GIT_TAG RESULT)
   string(LENGTH "${GIT_TAG}" length)
   # full hash has 40 characters, and short hash has at least 7 characters.

--- a/cmake/clang_tidy.cmake
+++ b/cmake/clang_tidy.cmake
@@ -1,18 +1,31 @@
 
 option(UUIDXX_ENABLE_CLANG_TIDY "Enable clang-tidy on build" OFF)
+message(STATUS "UUIDXX_ENABLE_CLANG_TIDY = ${UUIDXX_ENABLE_CLANG_TIDY}")
 
 if(UUIDXX_ENABLE_CLANG_TIDY)
   find_program(CLANG_TIDY_EXE
                NAMES clang-tidy
-               DOC "Path to clang-tidy executable")
-  if(NOT CLANG_TIDY_EXE)
-      message(STATUS "WARNING: clang-tidy Not found.")
-  else()
-      message(STATUS "UUIDXX_ENABLE_CLANG_TIDY = ON: ${CLANG_TIDY_EXE}")
-      set(CMAKE_CXX_CLANG_TIDY
-          "${CLANG_TIDY_EXE}"
-          -header-filter=uuidxx/)
-  endif()
-else()
-  message(STATUS "UUIDXX_ENABLE_CLANG_TIDY = OFF")
+               DOC "Path to clang-tidy executable"
+               REQUIRED)
+  message(STATUS "Found clang-tidy = ${CLANG_TIDY_EXE}")
 endif()
+
+function(uuidxx_apply_clang_tidy TARGET)
+  message(STATUS "Apply uuidxx clang-tidy for ${TARGET}")
+
+  if(MSVC AND CMAKE_GENERATOR MATCHES "Visual Studio")
+    set_target_properties(${TARGET} PROPERTIES
+      VS_GLOBAL_RunCodeAnalysis true
+      VS_GLOBAL_EnableClangTidyCodeAnalysis true
+    )
+  else()
+    set(CLANG_TIDY_COMMAND
+        "${CLANG_TIDY_EXE}"
+        "--quiet"
+        "-p" "'${CMAKE_BINARY_DIR}'"
+    )
+    set_target_properties(${TARGET} PROPERTIES
+      CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}"
+    )
+  endif()
+endfunction()

--- a/cmake/compiler_msvc.cmake
+++ b/cmake/compiler_msvc.cmake
@@ -12,7 +12,7 @@ if(UUIDXX_NOT_SUBPROJECT)
 endif()
 
 message(STATUS "UUIDXX_USE_MSVC_PARALLEL_BUILD = ${UUIDXX_USE_MSVC_PARALLEL_BUILD}")
-message(STATUS "UUIDXX_USE_MSVC_STATIC_ANALYSIS = $UUIDXX_USE_MSVC_STATIC_ANALYSIS}")
+message(STATUS "UUIDXX_USE_MSVC_STATIC_ANALYSIS = ${UUIDXX_USE_MSVC_STATIC_ANALYSIS}")
 message(STATUS "UUIDXX_USE_WIN32_LEAN_AND_MEAN = ${UUIDXX_USE_WIN32_LEAN_AND_MEAN}")
 
 function(uuidxx_apply_common_compile_options TARGET)
@@ -35,12 +35,9 @@ function(uuidxx_apply_common_compile_options TARGET)
       /wd4819 # source characters not in current code page.
 
       /Zc:inline            # Have the compiler eliminate unreferenced COMDAT functions and data before emitting the object file.
-      /Zc:referenceBinding  # Disallow temporaries from binding to non-const lvalue references.
       /Zc:rvalueCast        # Enforce the standard rules for explicit type conversion.
-      /Zc:implicitNoexcept  # Enable implicit noexcept specifications where required, such as destructors.
       /Zc:strictStrings     # Don't allow conversion from a string literal to mutable characters.
       /Zc:threadSafeInit    # Enable thread-safe function-local statics initialization.
-      /Zc:throwingNew       # Assume operator new throws on failure.
 
       /permissive-  # Be mean, don't allow bad non-standard stuff (C++/CLI, __declspec, etc. are all left intact).
   )
@@ -69,11 +66,17 @@ function(uuidxx_apply_msvc_static_analysis TARGET)
   target_compile_options(${TARGET}
     PRIVATE
       /analyze
-      /analyze:WX-
 
       /wd6001 # Using uninitialized memory.
       /wd6011 # Dereferencing potentially NULL pointer.
 
       ${ARG_WDL}
   )
+
+  if (CMAKE_GENERATOR MATCHES "Visual Studio")
+    set_target_properties(${TARGET} PROPERTIES
+      VS_GLOBAL_EnableMicrosoftCodeAnalysis true
+      VS_GLOBAL_RunCodeAnalysis true
+    )
+  endif()
 endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,19 +17,16 @@ target_link_libraries(uuidxx_test
 uuidxx_apply_common_compile_options(uuidxx_test)
 
 if(MSVC)
-  get_target_property(test_FILES uuidxx_test SOURCES)
-  source_group("tests" FILES ${test_FILES})
-
   if(UUIDXX_USE_MSVC_PARALLEL_BUILD)
     uuidxx_apply_msvc_parallel_build(uuidxx_test)
-  endif()
-  if(UUIDXX_USE_MSVC_STATIC_ANALYSIS)
-    uuidxx_apply_msvc_static_analysis(uuidxx_test)
   endif()
 else()
   if(UUIDXX_USE_SANITIZER)
     uuidxx_apply_sanitizer(uuidxx_test)
   endif()
 endif()
+
+get_target_property(test_FILES uuidxx_test SOURCES)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${test_FILES})
 
 add_test(NAME test_uuidxx COMMAND uuidxx_test)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -16,17 +16,14 @@ target_include_directories(hash
 uuidxx_apply_common_compile_options(hash)
 
 if(MSVC)
-  get_target_property(hash_FILES hash SOURCES)
-  source_group("hash" FILES ${hash_FILES})
-
   if(UUIDXX_USE_MSVC_PARALLEL_BUILD)
     uuidxx_apply_msvc_parallel_build(hash)
-  endif()
-  if(UUIDXX_USE_MSVC_STATIC_ANALYSIS)
-    uuidxx_apply_msvc_static_analysis(hash)
   endif()
 else()
   if(UUIDXX_USE_SANITIZER)
     uuidxx_apply_sanitizer(hash)
   endif()
 endif()
+
+get_target_property(hash_FILES hash SOURCES)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${hash_FILES})

--- a/uuidxx/CMakeLists.txt
+++ b/uuidxx/CMakeLists.txt
@@ -31,13 +31,18 @@ target_include_directories(uuidxx
 )
 
 target_link_libraries(uuidxx
-  INTERFACE
+  PUBLIC
     Threads::Threads
+
   PRIVATE
     hash
 )
 
 uuidxx_apply_common_compile_options(uuidxx)
+
+if(UUIDXX_ENABLE_CLANG_TIDY)
+  uuidxx_apply_clang_tidy(uuidxx)
+endif()
 
 if(MSVC)
   if(UUIDXX_USE_MSVC_PARALLEL_BUILD)
@@ -49,10 +54,11 @@ if(MSVC)
         /wd6011 # Dereferencing potentially NULL pointer.
     )
   endif()
-  get_target_property(uuidxx_FILES uuidxx SOURCES)
-  source_group("uuidxx" FILES ${uuidxx_FILES})
 else()
   if(UUIDXX_USE_SANITIZER)
     uuidxx_apply_sanitizer(uuidxx)
   endif()
 endif()
+
+get_target_property(uuidxx_FILES uuidxx SOURCES)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${uuidxx_FILES})

--- a/uuidxx/clock_sequence.cpp
+++ b/uuidxx/clock_sequence.cpp
@@ -9,8 +9,7 @@
 namespace uuidxx {
 
 clock_sequence::clock_sequence()
-    : last_time_(0),
-      seq_(static_cast<uint16_t>(std::random_device{}())) {}
+    : seq_(static_cast<uint16_t>(std::random_device{}())) {}
 
 // static
 clock_sequence& clock_sequence::instance() {
@@ -21,16 +20,16 @@ clock_sequence& clock_sequence::instance() {
 // static
 uint64_t clock_sequence::get_timestamp_since_epoch() {
     auto ts = k_epoch_diff + std::chrono::duration_cast<clock_sequence::duration>(
-                                 std::chrono::system_clock::now().time_since_epoch());
+                                     std::chrono::system_clock::now().time_since_epoch());
     return ts.count();
 }
 
 std::tuple<uint64_t, uint16_t> clock_sequence::read() {
-    uint64_t now = get_timestamp_since_epoch();
-    uint16_t seq;
+    const uint64_t now = get_timestamp_since_epoch();
+    uint16_t seq;   // NOLINT(cppcoreguidelines-init-variables)
 
     {
-        std::lock_guard lock(mtx_);
+        const std::lock_guard lock(mtx_);
 
         // The clock is set backward or read too fast.
         if (now <= last_time_) {

--- a/uuidxx/clock_sequence.h
+++ b/uuidxx/clock_sequence.h
@@ -38,7 +38,7 @@ private:
 
 private:
     std::mutex mtx_;
-    uint64_t last_time_;
+    uint64_t last_time_{0};
     uint16_t seq_;
 
     // Difference in 100ns intervals between UUID epoch (1582/10/15 00:00:00) and Unix

--- a/uuidxx/endian_utils.h
+++ b/uuidxx/endian_utils.h
@@ -6,120 +6,67 @@
 #define UUIDXX_ENDIAN_UTILS_H_
 
 #include <cstdint>
-#include <cstdlib>
 
-#if defined(__linux__)
-#include <endian.h>
+#if defined(_WIN32)
+#include <cstdlib>
+#else
+#include <byteswap.h>
 #endif
 
 namespace uuidxx {
 
-#if defined(__linux__)
+#if defined(_WIN32)
 
-// little-endian to big-endian
-
-inline int16_t host_to_network(int16_t n) noexcept {
-    return htobe16(n);
+inline std::int16_t byteswap(std::int16_t n) noexcept {
+    return static_cast<std::int16_t>(_byteswap_ushort(static_cast<std::uint16_t>(n)));
 }
 
-inline uint16_t host_to_network(uint16_t n) noexcept {
-    return htobe16(n);
-}
-
-inline int32_t host_to_network(int32_t n) noexcept {
-    return htobe32(n);
-}
-
-inline uint32_t host_to_network(uint32_t n) noexcept {
-    return htobe32(n);
-}
-
-inline int64_t host_to_network(int64_t n) noexcept {
-    return htobe64(n);
-}
-
-inline uint64_t host_to_network(uint64_t n) noexcept {
-    return htobe64(n);
-}
-
-// big-endian to little-endian
-
-inline int16_t network_to_host(int16_t n) noexcept {
-    return be16toh(n);
-}
-
-inline uint16_t network_to_host(uint16_t n) noexcept {
-    return be16toh(n);
-}
-
-inline int32_t network_to_host(int32_t n) noexcept {
-    return be32toh(n);
-}
-
-inline uint32_t network_to_host(uint32_t n) noexcept {
-    return be32toh(n);
-}
-
-inline int64_t network_to_host(int64_t n) noexcept {
-    return be64toh(n);
-}
-
-inline uint64_t network_to_host(uint64_t n) noexcept {
-    return be64toh(n);
-}
-
-#elif defined(_WIN32) || defined(_WIN64)
-
-// little-endian to big-endian
-
-inline int16_t host_to_network(int16_t n) noexcept {
+inline std::uint16_t byteswap(std::uint16_t n) noexcept {
     return _byteswap_ushort(n);
 }
 
-inline uint16_t host_to_network(uint16_t n) noexcept {
-    return _byteswap_ushort(n);
+inline std::int32_t byteswap(std::int32_t n) noexcept {
+    static_assert(sizeof(std::uint32_t) == sizeof(unsigned long)); // NOLINT(google-runtime-int)
+    return static_cast<std::int32_t>(_byteswap_ulong(static_cast<std::uint32_t>(n)));
 }
 
-inline int32_t host_to_network(int32_t n) noexcept {
+inline std::uint32_t byteswap(std::uint32_t n) noexcept {
+    static_assert(sizeof(std::uint32_t) == sizeof(unsigned long)); // NOLINT(google-runtime-int)
     return _byteswap_ulong(n);
 }
 
-inline uint32_t host_to_network(uint32_t n) noexcept {
-    return _byteswap_ulong(n);
+inline std::int64_t byteswap(std::int64_t n) noexcept {
+    return static_cast<std::int64_t>(_byteswap_uint64(static_cast<std::uint64_t>(n)));
 }
 
-inline int64_t host_to_network(int64_t n) noexcept {
+inline std::uint64_t byteswap(std::uint64_t n) noexcept {
     return _byteswap_uint64(n);
 }
 
-inline uint64_t host_to_network(uint64_t n) noexcept {
-    return _byteswap_uint64(n);
+#else
+
+inline std::int16_t byteswap(std::int16_t n) noexcept {
+    return static_cast<std::int16_t>(bswap_16(static_cast<std::uint16_t>(n)));
 }
 
-// big-endian to little-endian
-
-inline int16_t network_to_host(int16_t n) noexcept {
-    return _byteswap_ushort(n);
+inline std::uint16_t byteswap(std::uint16_t n) noexcept {
+    return bswap_16(n);
 }
 
-inline uint16_t network_to_host(uint16_t n) noexcept {
-    return _byteswap_ushort(n);
+inline std::int32_t byteswap(std::int32_t n) noexcept {
+    return static_cast<std::int32_t>(bswap_32(static_cast<std::uint32_t>(n)));
 }
 
-inline int32_t network_to_host(int32_t n) noexcept {
-    return _byteswap_ulong(n);
+inline std::uint32_t byteswap(std::uint32_t n) noexcept {
+    return bswap_32(n);
 }
 
-inline uint32_t network_to_host(uint32_t n) noexcept {
-    return _byteswap_ulong(n);
+inline std::int64_t byteswap(std::int64_t n) noexcept {
+    return static_cast<std::int64_t>(bswap_64(static_cast<std::uint64_t>(n)));
 }
 
-inline int64_t network_to_host(int64_t n) noexcept {
-    return _byteswap_uint64(n);
-}
-
-inline uint64_t network_to_host(uint64_t n) noexcept {
-    return _byteswap_uint64(n);
+inline std::uint64_t byteswap(std::uint64_t n) noexcept {
+    return bswap_64(n);
 }
 
 #endif

--- a/uuidxx/node_fetcher.cpp
+++ b/uuidxx/node_fetcher.cpp
@@ -24,7 +24,7 @@ void load_mac_address(node_id& addr) {
     std::memcpy(addr.data(), &rand, addr.size());
 
     // Recommended by RFC.
-    addr[0] |= 0x01;
+    addr[0] |= std::byte{0x01};
 }
 
 void read_mac_addr_as_node_id(node_id& id) {

--- a/uuidxx/node_fetcher.h
+++ b/uuidxx/node_fetcher.h
@@ -6,13 +6,13 @@
 #define UUIDXX_NODE_FETCHER_H_
 
 #include <array>
-#include <cstdint>
+#include <cstddef>
 #include <type_traits>
 
 namespace uuidxx {
 
 // A 48-bit device-related identifier.
-using node_id = std::array<uint8_t, 6>;
+using node_id = std::array<std::byte, 6>;
 
 template<typename Fetcher, typename = void>
 struct valid_fetcher_t : std::false_type {};

--- a/uuidxx/rand_generator.h
+++ b/uuidxx/rand_generator.h
@@ -37,7 +37,7 @@ public:
     }
 
     uint64_t operator()() {
-        std::lock_guard lock(mtx_);
+        const std::lock_guard lock(mtx_);
         return engine_();
     }
 

--- a/uuidxx/uuid.h
+++ b/uuidxx/uuid.h
@@ -6,6 +6,7 @@
 #define UUIDXX_UUID_H_
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <string>
@@ -58,11 +59,11 @@ inline constexpr gen_from_data_bytes_t gen_from_data_bytes{};
 
 namespace version {
 
-inline constexpr uint8_t v1 = 1u;
-inline constexpr uint8_t v2 = 2u;
-inline constexpr uint8_t v3 = 3u;
-inline constexpr uint8_t v4 = 4u;
-inline constexpr uint8_t v5 = 5u;
+inline constexpr uint8_t v1 = 1U;
+inline constexpr uint8_t v2 = 2U;
+inline constexpr uint8_t v3 = 3U;
+inline constexpr uint8_t v4 = 4U;
+inline constexpr uint8_t v5 = 5U;
 
 } // namespace version
 
@@ -111,8 +112,7 @@ public:
 
 public:
     template<typename NodeFetcher>
-    uuid(NodeFetcher&& fetch, details::gen_v1_t)
-        : data_{} {
+    uuid(NodeFetcher&& fetch, details::gen_v1_t) {
         static_assert(valid_fetcher_t<NodeFetcher>::value);
 
         auto [ts, seq] = clock_sequence::instance().read();
@@ -128,7 +128,7 @@ public:
         data_[1] |= static_cast<uint64_t>(seq & 0xff) << 48;
 
         // Reversely copy into 0 ~ 47 bits of data_[1].
-        auto ptr = reinterpret_cast<uint8_t*>(&data_[1]);
+        auto ptr = reinterpret_cast<std::byte*>(&data_[1]);
         for (auto it = id.rbegin(); it != id.rend();) {
             *ptr++ = *it++;
         }
@@ -156,8 +156,7 @@ public:
 
     uuid(std::string_view src, details::gen_from_str_t);
 
-    constexpr uuid(const data_bytes& bytes, details::gen_from_data_bytes_t)
-        : data_{} {
+    constexpr uuid(const data_bytes& bytes, details::gen_from_data_bytes_t) {
         data_[0] |= static_cast<uint64_t>(bytes.field1) << 32;
         data_[0] |= static_cast<uint64_t>(bytes.field2) << 16;
         data_[0] |= static_cast<uint64_t>(bytes.field3);
@@ -202,7 +201,7 @@ private:
     }
 
 private:
-    data data_;
+    data data_{0};
 };
 
 inline bool operator==(const uuid& lhs, const uuid& rhs) {


### PR DESCRIPTION
1. Update CMake files & build.py
2. Update clang-format file
3. Add support for clang-tidy and fix tidy issues
4. Rewrite endian util functions